### PR TITLE
Configure Output directory of FreeMarkerService

### DIFF
--- a/src/main/kotlin/HelloWorld.kt
+++ b/src/main/kotlin/HelloWorld.kt
@@ -1,7 +1,1 @@
-import models.BpmnObject
-
-fun main() {
-    println("Hello World!")
-    val testObject = BpmnObject("TestId", "Test-Object")
-    FreeMarkerService.writeTemplate(mapOf("bpmn" to testObject), "basic.ftl", outputPath = "out/reports/basicGeneratedOutput.html")
-}
+fun main() = println("Hello World!")

--- a/src/main/kotlin/info/novatec/cbdg/plugin/GenerateMojo.kt
+++ b/src/main/kotlin/info/novatec/cbdg/plugin/GenerateMojo.kt
@@ -1,6 +1,6 @@
 package info.novatec.cbdg.plugin
 
-import org.apache.commons.io.FileUtils
+import models.BpmnObject
 import org.apache.maven.plugin.AbstractMojo
 import org.apache.maven.plugins.annotations.Mojo
 import org.apache.maven.plugins.annotations.Parameter
@@ -8,8 +8,10 @@ import java.io.File
 import java.io.FileNotFoundException
 
 @Mojo(name = "generate")
-class GenerateMojo : AbstractMojo {
-    constructor() : super()
+class GenerateMojo : AbstractMojo() {
+
+    @Parameter(property = "templateFile", defaultValue = "\${project.basedir}/src/main/resources/templates/basic.ftl")
+    lateinit var templateFile: File
 
     @Parameter(property = "camundaBpmnDir", defaultValue = "\${project.basedir}/src/main/resources/bpmn")
     lateinit var camundaBpmnDir: File
@@ -19,8 +21,13 @@ class GenerateMojo : AbstractMojo {
 
     override fun execute() {
         camundaBpmnDir.listFiles()?.forEach {
-            log.info(it.absolutePath)
-            FileUtils.writeStringToFile(File(resultOutputDir.absolutePath, it.name + ".html"), "<html>" + it.absolutePath + "</html>", "UTF-8")
+            log.info("Generating documentation for file ${it.absolutePath}")
+            log.info("Using template ${templateFile.absolutePath}")
+            val bpmnObject = BpmnObject(id = "test-id", it.name)
+            FreeMarkerService.writeTemplate(bpmnObject, templateFile.name, "${resultOutputDir.absolutePath}/${it.nameWithoutExtension}.html") {
+                setDirectoryForTemplateLoading(templateFile.parentFile)
+            }
+            log.info("Output report into path ${resultOutputDir.absolutePath}")
         } ?: throw FileNotFoundException("${camundaBpmnDir.absolutePath} don't exist.")
         resultOutputDir.listFiles()?.forEach {
             log.info(it.absolutePath)

--- a/src/main/resources/META-INF/maven/info.novatec/camunda-bpmn-documentation-generator/plugin-help.xml
+++ b/src/main/resources/META-INF/maven/info.novatec/camunda-bpmn-documentation-generator/plugin-help.xml
@@ -36,10 +36,18 @@
 					<editable>true</editable>
 					<description/>
 				</parameter>
+				<parameter>
+					<name>templateFile</name>
+					<type>java.io.File</type>
+					<required>false</required>
+					<editable>true</editable>
+					<description/>
+				</parameter>
 			</parameters>
 			<configuration>
 				<camundaBpmnDir implementation="java.io.File" default-value="${project.basedir}/src/main/resources/bpmn">${camundaBpmnDir}</camundaBpmnDir>
 				<resultOutputDir implementation="java.io.File" default-value="${project.build.directory}/cbdg/html">${resultOutputDir}</resultOutputDir>
+				<templateFile implementation="java.io.File" default-value="${project.basedir}/src/main/resources/templates/basic.ftl">${templateFile}</templateFile>
 			</configuration>
 		</mojo>
 	</mojos>

--- a/src/main/resources/META-INF/maven/plugin.xml
+++ b/src/main/resources/META-INF/maven/plugin.xml
@@ -38,10 +38,18 @@
 					<editable>true</editable>
 					<description/>
 				</parameter>
+				<parameter>
+					<name>templateFile</name>
+					<type>java.io.File</type>
+					<required>false</required>
+					<editable>true</editable>
+					<description/>
+				</parameter>
 			</parameters>
 			<configuration>
 				<camundaBpmnDir implementation="java.io.File" default-value="${project.basedir}/src/main/resources/bpmn">${camundaBpmnDir}</camundaBpmnDir>
 				<resultOutputDir implementation="java.io.File" default-value="${project.build.directory}/cbdg/html">${resultOutputDir}</resultOutputDir>
+				<templateFile implementation="java.io.File" default-value="${project.basedir}/src/main/resources/templates/basic.ftl">${templateFile}</templateFile>
 			</configuration>
 		</mojo>
 	</mojos>


### PR DESCRIPTION
Added templateFile parameter to the GenerateMojo

Integrated FreeMarkerService into the GenerateMojo with a temporary fake object that is generated for testing purposes

Added optional on-the-go configuration to the FreemarkerService.writeTemplate method